### PR TITLE
Basic search operations implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,45 @@ MD5sum: 7ce70dc6e6de01134d2e199499fd3925
 SHA256: 0a40074c844a304688e503dd0c3f8b04e10e40f6f81b8bad260e07c54aa37864
 ```
 
+Search filtering by reposipotry
+
+```go
+package main
+
+import (
+	"fmt"
+
+	apt "github.com/Sfrisio/go-apt-search"
+)
+
+func main() {
+	availableRepo, errGetAvailableRepo := apt.GetAvailableRepo()
+	if errGetAvailableRepo != nil {
+		panic(errGetAvailableRepo)
+	}
+	var myRepo []apt.RepoArchive
+	for _, repo := range availableRepo {
+		if strings.Contains(repo.Domain, "deb.debian.org") {
+			myRepo = append(myRepo, repo)
+		}
+	}
+	searchResult, errAptSearch := apt.AptSearch("synaptic", myRepo, false)
+	if errAptSearch != nil {
+		panic(errAptSearch)
+	}
+	for _, singlePackage := range searchResult {
+		fmt.Printf("\n### %s ###\n", singlePackage.PackageName)
+		fmt.Printf("Version: %s\n", singlePackage.Version)
+		fmt.Printf("Architecture: %s\n", singlePackage.Architecture)
+		fmt.Printf("Depends: %s\n", singlePackage.Depends)
+		fmt.Printf("Description: %s\n", singlePackage.Description)
+		fmt.Printf("Section: %s\n", singlePackage.Section)
+		fmt.Printf("MD5sum: %s\n", singlePackage.Md5sum)
+		fmt.Printf("SHA256: %s\n", singlePackage.Sha256)
+	}
+}
+```
+
 List all available packages:
 
 ```go

--- a/go-apt-search.go
+++ b/go-apt-search.go
@@ -22,6 +22,14 @@ type APTPackages struct {
 	Sha256       string   `json:"SHA256"`
 }
 
+type RepoArchive struct {
+	Domain       string `json:"Domain"`
+	Distribution string `json:"Distribution"`
+	Area         string `json:"Area"`
+	Architecture string `json:"Architecture"`
+	ListFileName string `json:"ListFileName"`
+}
+
 // AptSearch: allows to perform a targeted search using the exact name of the package to be searched,
 //
 // or a keyword search that will result in all packages that include that string in the name
@@ -50,8 +58,64 @@ func AptListAll() ([]APTPackages, error) {
 	if errGetRepoFileList != nil {
 		return nil, errGetRepoFileList
 	}
-	var packagesList []APTPackages
+	allPackagesList, errBuildPackagesList := buildPackagesList(allPackagesFiles)
+	if errBuildPackagesList != nil {
+		return nil, errBuildPackagesList
+	}
+	return allPackagesList, nil
+}
+
+// GetRepoDomain: returns a list of currently active repositories by distribution and area
+func GetRepoDomain() ([]RepoArchive, error) {
+	repoList, errGetRepoFileList := getRepoFileList()
+	if errGetRepoFileList != nil {
+		return nil, errGetRepoFileList
+	}
+	var repoDomainList []RepoArchive
+	for _, repo := range repoList {
+		repoDomain := strings.Split(repo, "_")
+		var extractedDistribution string
+		var extractedArea string
+		for i, repoFields := range repoDomain {
+			if repoFields == "dists" {
+				extractedDistribution = repoDomain[i+1]
+				extractedArea = repoDomain[i+2]
+			}
+		}
+		repoDomainList = append(repoDomainList, RepoArchive{
+			Domain:       repoDomain[0],
+			Distribution: extractedDistribution,
+			Area:         extractedArea,
+			Architecture: repoDomain[len(repoDomain)-2],
+			ListFileName: repo,
+		})
+
+	}
+	return repoDomainList, nil
+}
+
+// getRepoFileList: read files from /var/lib/apt/lists and return only packages
+//
+// I preferred to use os.ReadDir instead of filepath.Walk because I am not interested in the list of files in the partial directory
+func getRepoFileList() ([]string, error) {
+	allPackagesFiles, errReadDir := os.ReadDir(aptListPath)
+	if errReadDir != nil {
+		return nil, errReadDir
+	}
+	var matchingPackagesFiles []string
+	filterPackagesFile, _ := regexp.Compile(`.*\_Packages$`)
 	for _, packagesFile := range allPackagesFiles {
+		if filterPackagesFile.MatchString(packagesFile.Name()) {
+			matchingPackagesFiles = append(matchingPackagesFiles, packagesFile.Name())
+		}
+	}
+	return matchingPackagesFiles, nil
+}
+
+// buildPackagesList: return packages available from a list of repositories
+func buildPackagesList(repoList []string) ([]APTPackages, error) {
+	var packagesList []APTPackages
+	for _, packagesFile := range repoList {
 		readPackageFile, errOpen := os.ReadFile(filepath.Join(aptListPath, packagesFile))
 		if errOpen != nil {
 			return nil, errOpen
@@ -99,22 +163,4 @@ func AptListAll() ([]APTPackages, error) {
 		}
 	}
 	return packagesList, nil
-}
-
-// getRepoFileList: read files from /var/lib/apt/lists and return only packages
-//
-// I preferred to use os.ReadDir instead of filepath.Walk because I am not interested in the list of files in the partial directory
-func getRepoFileList() ([]string, error) {
-	allPackagesFiles, errReadDir := os.ReadDir(aptListPath)
-	if errReadDir != nil {
-		return nil, errReadDir
-	}
-	var matchingPackagesFiles []string
-	filterPackagesFile, _ := regexp.Compile(`.*\_Packages$`)
-	for _, packagesFile := range allPackagesFiles {
-		if filterPackagesFile.MatchString(packagesFile.Name()) {
-			matchingPackagesFiles = append(matchingPackagesFiles, packagesFile.Name())
-		}
-	}
-	return matchingPackagesFiles, nil
 }

--- a/go-apt-search.go
+++ b/go-apt-search.go
@@ -52,8 +52,8 @@ func AptSearch(searchPackage string, packagesList []APTPackages, searchExactName
 	return filteredPackageList, nil
 }
 
-// AptListALL: scan the source.list on the system and return the list of all available packages
-func AptListAll() ([]APTPackages, error) {
+// AptListALL: scan the all source.list on the system and return the list of all available packages
+func AptListAllPackages() ([]APTPackages, error) {
 	allPackagesFiles, errGetRepoFileList := getRepoFileList()
 	if errGetRepoFileList != nil {
 		return nil, errGetRepoFileList
@@ -65,8 +65,24 @@ func AptListAll() ([]APTPackages, error) {
 	return allPackagesList, nil
 }
 
+// AptListPackagesInRepo: scans only specific source.lists and returns the packages available into them
+func AptListPackagesInRepo(selectedRepo []RepoArchive) ([]APTPackages, error) {
+	if len(selectedRepo) == 0 {
+		return nil, fmt.Errorf("please provide at least one repository")
+	}
+	var repoFileList []string
+	for _, selectedRepoFile := range selectedRepo {
+		repoFileList = append(repoFileList, selectedRepoFile.ListFileName)
+	}
+	filteredPackagesList, errBuildPackagesList := buildPackagesList(repoFileList)
+	if errBuildPackagesList != nil {
+		return nil, errBuildPackagesList
+	}
+	return filteredPackagesList, nil
+}
+
 // GetRepoDomain: returns a list of currently active repositories by distribution and area
-func GetRepoDomain() ([]RepoArchive, error) {
+func GetAvailableRepo() ([]RepoArchive, error) {
 	repoList, errGetRepoFileList := getRepoFileList()
 	if errGetRepoFileList != nil {
 		return nil, errGetRepoFileList

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/Sfrisio/go-apt-search
 
-go 1.20
+go 1.21


### PR DESCRIPTION
It is currently possible to retrieve all packages available in the repositories, and it is also possible to search using an exact string or a package containing a specific string.
The search can also be done by filtering by repository

Moving to Go 1.21.0